### PR TITLE
chore: Update GreptimeDB version to v0.15.0

### DIFF
--- a/Formula/greptime.rb
+++ b/Formula/greptime.rb
@@ -1,15 +1,15 @@
 class Greptime < Formula
   desc "An open-source, cloud-native, distributed time-series database with PromQL/SQL/Python supported."
   homepage "https://github.com/GreptimeTeam/greptimedb"
-  version "v0.14.4"
+  version "v0.15.0"
   license "Apache-2.0"
 
   if Hardware::CPU.intel?
-    url "https://github.com/GreptimeTeam/greptimedb/releases/download/v0.14.4/greptime-darwin-amd64-v0.14.4.tar.gz"
-    sha256 "af6fc11b537460d2022498386b1b5d0b974c4fb69b772ae43deea2dcfbc98a0c"
+    url "https://github.com/GreptimeTeam/greptimedb/releases/download/v0.15.0/greptime-darwin-amd64-v0.15.0.tar.gz"
+    sha256 "5dbede0a9358e0f98e33245f68b87a102074b0ed2614c9c87f42b5435b42aa77"
   elsif Hardware::CPU.arm?
-    url "https://github.com/GreptimeTeam/greptimedb/releases/download/v0.14.4/greptime-darwin-arm64-v0.14.4.tar.gz"
-    sha256 "8fa3debcfe79a942d97d577eecba6ec50b1c7a101a49054ab8ae603239499457"
+    url "https://github.com/GreptimeTeam/greptimedb/releases/download/v0.15.0/greptime-darwin-arm64-v0.15.0.tar.gz"
+    sha256 "bbfa2166c0a0a990adeef19c09ead0595fa0f5bace4271d03fda1612d5ff34d8"
   end
 
   def install


### PR DESCRIPTION
This PR updates the GreptimeDB version.