### PR TITLE
chore: Update GreptimeDB version to v0.15.1

### DIFF
--- a/Formula/greptime.rb
+++ b/Formula/greptime.rb
@@ -1,15 +1,15 @@
 class Greptime < Formula
   desc "An open-source, cloud-native, distributed time-series database with PromQL/SQL/Python supported."
   homepage "https://github.com/GreptimeTeam/greptimedb"
-  version "v0.15.0"
+  version "v0.15.1"
   license "Apache-2.0"
 
   if Hardware::CPU.intel?
-    url "https://github.com/GreptimeTeam/greptimedb/releases/download/v0.15.0/greptime-darwin-amd64-v0.15.0.tar.gz"
-    sha256 "5dbede0a9358e0f98e33245f68b87a102074b0ed2614c9c87f42b5435b42aa77"
+    url "https://github.com/GreptimeTeam/greptimedb/releases/download/v0.15.1/greptime-darwin-amd64-v0.15.1.tar.gz"
+    sha256 "39d7f7b905ad070c7c418cc8e59629765cf573ffb24c321dc52dd28651494635"
   elsif Hardware::CPU.arm?
-    url "https://github.com/GreptimeTeam/greptimedb/releases/download/v0.15.0/greptime-darwin-arm64-v0.15.0.tar.gz"
-    sha256 "bbfa2166c0a0a990adeef19c09ead0595fa0f5bace4271d03fda1612d5ff34d8"
+    url "https://github.com/GreptimeTeam/greptimedb/releases/download/v0.15.1/greptime-darwin-arm64-v0.15.1.tar.gz"
+    sha256 "cea4784a1baf3901497008c85c19d55b05f08ef7d11e5fb8cf351487478b0fc2"
   end
 
   def install


### PR DESCRIPTION
This PR updates the GreptimeDB version.