### PR TITLE
chore: Update GreptimeDB version to v0.15.2

### DIFF
--- a/Formula/greptime.rb
+++ b/Formula/greptime.rb
@@ -1,15 +1,15 @@
 class Greptime < Formula
   desc "An open-source, cloud-native, distributed time-series database with PromQL/SQL/Python supported."
   homepage "https://github.com/GreptimeTeam/greptimedb"
-  version "v0.15.1"
+  version "v0.15.2"
   license "Apache-2.0"
 
   if Hardware::CPU.intel?
-    url "https://github.com/GreptimeTeam/greptimedb/releases/download/v0.15.1/greptime-darwin-amd64-v0.15.1.tar.gz"
-    sha256 "39d7f7b905ad070c7c418cc8e59629765cf573ffb24c321dc52dd28651494635"
+    url "https://github.com/GreptimeTeam/greptimedb/releases/download/v0.15.2/greptime-darwin-amd64-v0.15.2.tar.gz"
+    sha256 "7f961617495def1fd8c819c58a60d8f584caecac5268a289b076d5e96ac2f528"
   elsif Hardware::CPU.arm?
-    url "https://github.com/GreptimeTeam/greptimedb/releases/download/v0.15.1/greptime-darwin-arm64-v0.15.1.tar.gz"
-    sha256 "cea4784a1baf3901497008c85c19d55b05f08ef7d11e5fb8cf351487478b0fc2"
+    url "https://github.com/GreptimeTeam/greptimedb/releases/download/v0.15.2/greptime-darwin-arm64-v0.15.2.tar.gz"
+    sha256 "0812bc129aa74cec9113534e8a725e0b10b7ef3ed9d66e30d76678587896efc0"
   end
 
   def install


### PR DESCRIPTION
This PR updates the GreptimeDB version.