### PR TITLE
chore: Update GreptimeDB version to v0.15.4

### DIFF
--- a/Formula/greptime.rb
+++ b/Formula/greptime.rb
@@ -1,15 +1,15 @@
 class Greptime < Formula
   desc "An open-source, cloud-native, distributed time-series database with PromQL/SQL/Python supported."
   homepage "https://github.com/GreptimeTeam/greptimedb"
-  version "v0.15.3"
+  version "v0.15.4"
   license "Apache-2.0"
 
   if Hardware::CPU.intel?
-    url "https://github.com/GreptimeTeam/greptimedb/releases/download/v0.15.3/greptime-darwin-amd64-v0.15.3.tar.gz"
-    sha256 "74aa606c0239e619d03303a244008dc97135ff9d033e8cae9d466a38574036a1"
+    url "https://github.com/GreptimeTeam/greptimedb/releases/download/v0.15.4/greptime-darwin-amd64-v0.15.4.tar.gz"
+    sha256 "72b6207263bc0a5e9e5644377609f571a2917c72dfa20f59d4ff09df783b5381"
   elsif Hardware::CPU.arm?
-    url "https://github.com/GreptimeTeam/greptimedb/releases/download/v0.15.3/greptime-darwin-arm64-v0.15.3.tar.gz"
-    sha256 "933f5d3fdf4c070c0a76b571b2e1b3780a486e26f626a82ff70ebb5468400d13"
+    url "https://github.com/GreptimeTeam/greptimedb/releases/download/v0.15.4/greptime-darwin-arm64-v0.15.4.tar.gz"
+    sha256 "1cfece3e11f47613e0a2d4d109f780812b937591ccd05e9f86327d709e99af1d"
   end
 
   def install


### PR DESCRIPTION
This PR updates the GreptimeDB version.