### PR TITLE
chore: Update GreptimeDB version to v0.15.5

### DIFF
--- a/Formula/greptime.rb
+++ b/Formula/greptime.rb
@@ -1,15 +1,15 @@
 class Greptime < Formula
   desc "An open-source, cloud-native, distributed time-series database with PromQL/SQL/Python supported."
   homepage "https://github.com/GreptimeTeam/greptimedb"
-  version "v0.16.0"
+  version "v0.15.5"
   license "Apache-2.0"
 
   if Hardware::CPU.intel?
-    url "https://github.com/GreptimeTeam/greptimedb/releases/download/v0.16.0/greptime-darwin-amd64-v0.16.0.tar.gz"
-    sha256 "e4679a26240753840e72476d8bba445979be9b4c9a0cf31439f0b678dd982a83"
+    url "https://github.com/GreptimeTeam/greptimedb/releases/download/v0.15.5/greptime-darwin-amd64-v0.15.5.tar.gz"
+    sha256 "5e5c124ee87821ec57e0ccf6e5536b5df2d3e6724823ef044c912afdb13e368f"
   elsif Hardware::CPU.arm?
-    url "https://github.com/GreptimeTeam/greptimedb/releases/download/v0.16.0/greptime-darwin-arm64-v0.16.0.tar.gz"
-    sha256 "6b7f763c9a08f60241b0b6b077025fce35d64d0e93cab40f897ea43ffc904415"
+    url "https://github.com/GreptimeTeam/greptimedb/releases/download/v0.15.5/greptime-darwin-arm64-v0.15.5.tar.gz"
+    sha256 "579e9171b18aacd52245863208478037a81189b12b9e64a36c43a0377aac63d8"
   end
 
   def install


### PR DESCRIPTION
This PR updates the GreptimeDB version.