### PR TITLE
chore: Update GreptimeDB version to v0.17.0

### DIFF
--- a/Formula/greptime.rb
+++ b/Formula/greptime.rb
@@ -1,15 +1,15 @@
 class Greptime < Formula
   desc "An open-source, cloud-native, distributed time-series database with PromQL/SQL/Python supported."
   homepage "https://github.com/GreptimeTeam/greptimedb"
-  version "v0.16.0"
+  version "v0.17.0"
   license "Apache-2.0"
 
   if Hardware::CPU.intel?
-    url "https://github.com/GreptimeTeam/greptimedb/releases/download/v0.16.0/greptime-darwin-amd64-v0.16.0.tar.gz"
-    sha256 "e4679a26240753840e72476d8bba445979be9b4c9a0cf31439f0b678dd982a83"
+    url "https://github.com/GreptimeTeam/greptimedb/releases/download/v0.17.0/greptime-darwin-amd64-v0.17.0.tar.gz"
+    sha256 "d09f07227902ae9924e573d3e20a276d115b7dc1c588afd13fafe3b39c22f53f"
   elsif Hardware::CPU.arm?
-    url "https://github.com/GreptimeTeam/greptimedb/releases/download/v0.16.0/greptime-darwin-arm64-v0.16.0.tar.gz"
-    sha256 "6b7f763c9a08f60241b0b6b077025fce35d64d0e93cab40f897ea43ffc904415"
+    url "https://github.com/GreptimeTeam/greptimedb/releases/download/v0.17.0/greptime-darwin-arm64-v0.17.0.tar.gz"
+    sha256 "a7fa5b48585531ad052d21a1f9c2db15bb41631ed5afebdd7ce4a6a5700218fb"
   end
 
   def install


### PR DESCRIPTION
This PR updates the GreptimeDB version.