### PR TITLE
chore: Update GreptimeDB version to v0.17.1

### DIFF
--- a/Formula/greptime.rb
+++ b/Formula/greptime.rb
@@ -1,15 +1,15 @@
 class Greptime < Formula
   desc "An open-source, cloud-native, distributed time-series database with PromQL/SQL/Python supported."
   homepage "https://github.com/GreptimeTeam/greptimedb"
-  version "v0.17.0"
+  version "v0.17.1"
   license "Apache-2.0"
 
   if Hardware::CPU.intel?
-    url "https://github.com/GreptimeTeam/greptimedb/releases/download/v0.17.0/greptime-darwin-amd64-v0.17.0.tar.gz"
-    sha256 "d09f07227902ae9924e573d3e20a276d115b7dc1c588afd13fafe3b39c22f53f"
+    url "https://github.com/GreptimeTeam/greptimedb/releases/download/v0.17.1/greptime-darwin-amd64-v0.17.1.tar.gz"
+    sha256 "1af427b7a017932c2e488b1c8bdb7893aa48fbb3ceb34985c15b6e2fd0ea7a21"
   elsif Hardware::CPU.arm?
-    url "https://github.com/GreptimeTeam/greptimedb/releases/download/v0.17.0/greptime-darwin-arm64-v0.17.0.tar.gz"
-    sha256 "a7fa5b48585531ad052d21a1f9c2db15bb41631ed5afebdd7ce4a6a5700218fb"
+    url "https://github.com/GreptimeTeam/greptimedb/releases/download/v0.17.1/greptime-darwin-arm64-v0.17.1.tar.gz"
+    sha256 "d54922a4624be6698ca1c732098bfa263ae3fbf298d26cec46942334c8221c9e"
   end
 
   def install


### PR DESCRIPTION
This PR updates the GreptimeDB version.