### PR TITLE
chore: Update GreptimeDB version to v1.0.0-rc.2

### DIFF
--- a/Formula/greptime.rb
+++ b/Formula/greptime.rb
@@ -1,15 +1,15 @@
 class Greptime < Formula
   desc "An open-source, cloud-native, distributed time-series database with PromQL/SQL/Python supported."
   homepage "https://github.com/GreptimeTeam/greptimedb"
-  version "v1.0.0-rc.1"
+  version "v1.0.0-rc.2"
   license "Apache-2.0"
 
   if Hardware::CPU.intel?
-    url "https://github.com/GreptimeTeam/greptimedb/releases/download/v1.0.0-rc.1/greptime-darwin-amd64-v1.0.0-rc.1.tar.gz"
-    sha256 "9e560f158d45bcf479c146c0149041cc8277d629bfe1607b9a41355a8840251a"
+    url "https://github.com/GreptimeTeam/greptimedb/releases/download/v1.0.0-rc.2/greptime-darwin-amd64-v1.0.0-rc.2.tar.gz"
+    sha256 "7348830bd9730125ee1fb778e9a3801b3e806eb3a860eb64c74b83285173d1ae"
   elsif Hardware::CPU.arm?
-    url "https://github.com/GreptimeTeam/greptimedb/releases/download/v1.0.0-rc.1/greptime-darwin-arm64-v1.0.0-rc.1.tar.gz"
-    sha256 "f75092912e6d3dd70217eef157d5fecdeba1cf3dceec9a748c052646f7e8919a"
+    url "https://github.com/GreptimeTeam/greptimedb/releases/download/v1.0.0-rc.2/greptime-darwin-arm64-v1.0.0-rc.2.tar.gz"
+    sha256 "58ae9f034cd419e52e3d0895d15fc2fd98046a35ffee51e6508a828b34ad0176"
   end
 
   def install


### PR DESCRIPTION
This PR updates the GreptimeDB version.